### PR TITLE
fix(): sw test can always get a browser

### DIFF
--- a/ServiceWorker/index.ts
+++ b/ServiceWorker/index.ts
@@ -9,7 +9,7 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
 
   const url = req.query.site;
 
-  const currentBrowser = getBrowser();
+  const currentBrowser = await getBrowser();
 
   try {
     // run lighthouse audit

--- a/utils/loadPage.ts
+++ b/utils/loadPage.ts
@@ -38,11 +38,17 @@ export default async function loadPage(site: string): Promise<{ sitePage: puppet
   }
 }
 
-export function getBrowser(): puppeteer.Browser | null {
+export async function getBrowser(): Promise<puppeteer.Browser> {
   if (browser) {
     return browser;
   }
   else {
-    return null
+    browser = await puppeteer.launch(
+      {
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      }
+    );
+    return browser;
   }
 }


### PR DESCRIPTION
We spin up a browser if one is not already running. This fixes an issue where the SW test sometimes would not get a browser object and thus would fail to run: 
![image](https://user-images.githubusercontent.com/8823093/99710414-616c3400-2a55-11eb-9f6e-eb1336589632.png)
