### PR TITLE
fix(): ensure we only ever spin up one browser

### DIFF
--- a/utils/loadPage.ts
+++ b/utils/loadPage.ts
@@ -9,12 +9,7 @@ export default async function loadPage(site: string): Promise<{ sitePage: puppet
   const timeout = 120000;
 
   try {
-    browser = await puppeteer.launch(
-      {
-        headless: true,
-        args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      }
-    );
+    browser = await getBrowser();
 
     sitePage = await browser.newPage();
 


### PR DESCRIPTION
After looking into the loadPage test and some errors we were getting in Azure, I realized we were spinning up a new browser instance every time the loadPage function was called. This extends from my last fix and uses the "getBrowser" function in the default loadPage call to ensure that we are only ever using one browser.