### PR TITLE
fix(): browser instances organized

### DIFF
--- a/Offline/index.ts
+++ b/Offline/index.ts
@@ -1,5 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import loadPage from "../utils/loadPage";
+import loadPage, { closeBrowser } from "../utils/loadPage";
 
 const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   context.log.info(`Offline function is processing a request for site: ${req.query.site}`);
@@ -51,6 +51,8 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
       await page.reload({ waitUntil: 'domcontentloaded' });
 
       if (bodySelector) {
+        await closeBrowser(context, pageData.browser);
+
         context.res = {
           status: 200,
           body: {
@@ -60,6 +62,8 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
       }
     }
     catch (err) {
+      await closeBrowser(context, pageData.browser);
+
       context.res = {
         status: 400,
         body: {
@@ -71,6 +75,8 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
     }
   }
   catch (err) {
+    await closeBrowser(context, pageData.browser);
+
     context.res = {
       status: 500,
       body: {

--- a/Site/index.ts
+++ b/Site/index.ts
@@ -1,9 +1,11 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import * as puppeteer from "puppeteer";
+
 import getManifestFromFile, {
   ifSupportedFile,
 } from "../utils/getManifestFromFile";
 import getManifest from "../utils/getManifest";
+
 import { ExceptionMessage, ExceptionWrap } from "../utils/Exception";
 import { Manifest, ManifestFormat, ManifestInfo } from "../utils/interfaces";
 const manifestTools = require("pwabuilder-lib").manifestTools;
@@ -14,13 +16,7 @@ const httpTrigger: AzureFunction = async function (
 ): Promise<void> {
   context.log.info(`Site function is processing a request for site: ${req.query.site}`);
 
-  let browser: puppeteer.Browser | null = null;
-
   try {
-    browser = await puppeteer.launch({
-      headless: true,
-      args: ["--no-sandbox", "--disable-setuid-sandbox"],
-    });
 
     let manifestUrl: string;
     let manifest: Manifest | null = null;
@@ -99,10 +95,6 @@ const httpTrigger: AzureFunction = async function (
       };
 
       context.log.error(`Site function errored getting the manifest for site: ${req.query.site}`);
-    }
-  } finally {
-    if (browser) {
-      browser.close();
     }
   }
 };

--- a/utils/Exception.ts
+++ b/utils/Exception.ts
@@ -4,6 +4,7 @@ export enum ExceptionType {
   BLOB_STORAGE_FAILURE = "BLOB_STORAGE_FAILURE",
   BLOB_STORAGE_FAILURE_IMAGE = "BLOB_STORAGE_FAILURE_IMAGE",
   BLOB_READ_FAILURE = "BLOB_READ_FAILURE",
+  BROWSER_CLOSE_FAILURE = "BROWSER_CLOSE_FAILURE",
 }
 
 export enum ExceptionMessage {
@@ -12,6 +13,7 @@ export enum ExceptionMessage {
   BLOB_STORAGE_FAILURE = "failed to create the azure resources for generating the app",
   BLOB_STORAGE_FAILURE_IMAGE = "failed to upload image to blob storage",
   BLOB_READ_FAILURE = "failed to fetch resource from blob storage",
+  BROWSER_CLOSE_FAILURE = "Failed to close browser",
 }
 
 /*

--- a/utils/getManifest.ts
+++ b/utils/getManifest.ts
@@ -2,7 +2,7 @@ import { Context } from "@azure/functions";
 import fetch from "node-fetch";
 import ExceptionOf, { ExceptionType as Type } from "./Exception";
 import { Manifest } from "./interfaces";
-import loadPage from "./loadPage";
+import loadPage, { closeBrowser } from "./loadPage";
 
 export interface ManifestInformation {
   json: Manifest;
@@ -38,6 +38,9 @@ export default async function getManifest(
 
     if (manifestUrl) {
       const response = await fetch(manifestUrl);
+
+      await closeBrowser(context, siteData.browser);
+
       return {
         json: await response.json(),
         url: manifestUrl,

--- a/utils/loadPage.ts
+++ b/utils/loadPage.ts
@@ -1,7 +1,7 @@
 import { Context } from '@azure/functions';
 import * as puppeteer from 'puppeteer';
-
-let browser: puppeteer.Browser;
+import ExceptionOf, { ExceptionType as Type } from "./Exception";
+import { LogMessages } from './logMessages';
 
 export default async function loadPage(site: string, context: Context): Promise<{ sitePage: puppeteer.Page, pageResponse: puppeteer.Response, browser: puppeteer.Browser }> {
   let sitePage: puppeteer.Page;
@@ -10,7 +10,7 @@ export default async function loadPage(site: string, context: Context): Promise<
   const timeout = 120000;
 
   try {
-    browser = await getBrowser(context);
+    const browser = await getBrowser(context);
 
     sitePage = await browser.newPage();
 
@@ -35,18 +35,27 @@ export default async function loadPage(site: string, context: Context): Promise<
 }
 
 export async function getBrowser(context: Context): Promise<puppeteer.Browser> {
+  context.log.info(LogMessages.OPENING_BROWSER);
+
+  const browser = await puppeteer.launch(
+    {
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    }
+  );
+  return browser;
+}
+
+export async function closeBrowser(context: Context, browser: puppeteer.Browser): Promise<void> {
   if (browser) {
-    context.log.info("Getting an already created browser");
-    return browser;
-  }
-  else {
-    context.log.info("Spinning up a new browser");
-    browser = await puppeteer.launch(
-      {
-        headless: true,
-        args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      }
-    );
-    return browser;
+    context.log.info(LogMessages.CLOSING_BROWSER);
+
+    try {
+      await browser.close();
+    }
+    catch(err) {
+      throw ExceptionOf(Type.BROWSER_CLOSE_FAILURE, err);
+      return err;
+    }
   }
 }

--- a/utils/logMessages.ts
+++ b/utils/logMessages.ts
@@ -1,0 +1,4 @@
+export enum LogMessages {
+  CLOSING_BROWSER = "Closing the browser instance",
+  OPENING_BROWSER = "Spinning up a browser instance"
+}


### PR DESCRIPTION
This PR makes two big functional changes to the code:

- We should only ever have a max of 3 browser instances at a time now per request to the API (one for each main test function)
- Each function will ALWAYS close its browser instance before sending back any response (even an error response)
