### PR TITLE
fix(): import puppeteer correctly

### DIFF
--- a/Site/index.ts
+++ b/Site/index.ts
@@ -1,5 +1,4 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import * as puppeteer from "puppeteer";
 
 import getManifestFromFile, {
   ifSupportedFile,

--- a/utils/loadPage.ts
+++ b/utils/loadPage.ts
@@ -1,5 +1,5 @@
 import { Context } from '@azure/functions';
-import * as puppeteer from 'puppeteer';
+import puppeteer from 'puppeteer';
 import ExceptionOf, { ExceptionType as Type } from "./Exception";
 import { LogMessages } from './logMessages';
 


### PR DESCRIPTION
This was the issue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31796 . I change the import as this issue suggested. Also, we were importing puppeteer in the site function when we didn't need too. Because of the style of import we WERE using, VSCode wasn't catching that, but changing the import style uncovered that.