### PR TITLE
Supported blob URLs for manifest

### DIFF
--- a/WebManifest/index.ts
+++ b/WebManifest/index.ts
@@ -48,14 +48,16 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
     }
   }
   catch (err) {
+    const error = err as Error;
+    const errorMessage = error?.message || `${err}`;
     context.res = {
       status: 400,
       body: {
-        "error": { error: err, message: err.message }
+        "error": { error: err, message: errorMessage }
       },
     };
 
-    context.log.error(`Web Manifest function has ERRORED while processing for site: ${req.query.site} with this error: ${err.message}`);
+    context.log.error(`Web Manifest function has ERRORED while processing for site: ${req.query.site} with this error: ${errorMessage}`);
   }
 };
 

--- a/utils/getManifest.ts
+++ b/utils/getManifest.ts
@@ -2,7 +2,7 @@ import { Context } from '@azure/functions';
 import fetch from 'node-fetch';
 import ExceptionOf, { ExceptionType as Type } from './Exception';
 import { Manifest } from './interfaces';
-import loadPage, { closeBrowser } from './loadPage';
+import loadPage, { closeBrowser, LoadedPage } from './loadPage';
 
 export interface ManifestInformation {
   json: Manifest;
@@ -13,15 +13,17 @@ export default async function getManifest(
   site: string,
   context: Context
 ): Promise<ManifestInformation | undefined> {
+  let siteData: LoadedPage | null = null;
   try {
     context.log.info('getManifest');
-    const siteData = await loadPage(site, context);
+    const siteDataOrError = await loadPage(site, context);
 
-    if (siteData instanceof Error || !siteData) {
+    if (siteDataOrError instanceof Error || !siteDataOrError) {
       context.log.info('did not get manifest');
       return undefined;
     }
 
+    siteData = siteDataOrError;
     siteData.sitePage.setRequestInterception(true);
 
     const whiteList = ['document', 'plain', 'script', 'javascript'];
@@ -43,18 +45,30 @@ export default async function getManifest(
     );
 
     if (manifestUrl) {
-      const response = await fetch(manifestUrl);
+      let jsonResult: any;
 
-      await closeBrowser(context, siteData.browser);
+      // If it's a blob: URL, we need to ask the browser to fetch it for us.
+      // Reason is, node-fetch doesn't currently support fetching non HTTP(S) URLs.
+      // See https://microsoft.visualstudio.com/OS/_workitems/edit/33479686
+      if (manifestUrl.startsWith("blob:")) {
+        jsonResult = await siteData.sitePage.evaluate(`fetch(${manifestUrl}).json()`);
+      } else {
+        // It's a normal URL. Use node-fetch to grab it.
+        jsonResult = await (await fetch(manifestUrl)).json();
+      }
 
       return {
-        json: await response.json(),
+        json: jsonResult,
         url: manifestUrl,
       };
     }
 
     return undefined;
   } catch (e) {
-    throw ExceptionOf(Type.MANIFEST_NOT_FOUND, e);
+    throw ExceptionOf(Type.MANIFEST_NOT_FOUND, e as Error);
+  } finally {
+    if (siteData) {
+      await closeBrowser(context, siteData.browser);
+    }
   }
 }

--- a/utils/loadPage.ts
+++ b/utils/loadPage.ts
@@ -39,7 +39,7 @@ export default async function loadPage(
       throw new Error("Could not get a page response");
     }
   } catch (err) {
-    return err;
+    return err as Error;
   }
 }
 
@@ -63,8 +63,7 @@ export async function closeBrowser(
     try {
       await browser.close();
     } catch (err) {
-      throw ExceptionOf(Type.BROWSER_CLOSE_FAILURE, err);
-      return err;
+      console.warn("Error closing browser", err);
     }
   }
 }


### PR DESCRIPTION
Manifest URLs set to a blob URL now supported. Fixes https://microsoft.visualstudio.com/OS/_workitems/edit/33479686

Cleans up the Puppeteer browser instance in a more reliable way.

Fixes some TypeScript compiler errors arising from the new default where caught exceptions are of type `unknown`.